### PR TITLE
[BC BREAK] Remove DefaultConfigLoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ func New(context context.Context) *MyConfig {
 		BDDPassword: "my_fake_password",
 	}
 
-	config.NewDefaultConfigLoader().LoadOrFatal(context, cfg) // It use the DefaultConfigLoader
+	config.NewDefaultConfigLoader().LoadOrFatal(context, cfg)
 	return cfg
 }
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ func New(context context.Context) *MyConfig {
 		BDDPassword: "my_fake_password",
 	}
 
-	config.LoadOrFatal(context, cfg) // It use the DefaultConfigLoader
+	config.NewDefaultConfigLoader().LoadOrFatal(context, cfg) // It use the DefaultConfigLoader
 	return cfg
 }
 

--- a/dotenv/dotenv.go
+++ b/dotenv/dotenv.go
@@ -2,11 +2,20 @@ package dotenv
 
 import (
 	"context"
+	"flag"
 	"fmt"
+	"os"
 	"regexp"
+	"strings"
+	"sync"
 
 	"github.com/heetch/confita/backend"
 	"github.com/joho/godotenv"
+)
+
+var (
+	envFiles string
+	o        sync.Once
 )
 
 func NewBackend(filenames ...string) backend.Backend {
@@ -31,4 +40,22 @@ func NewBackend(filenames ...string) backend.Backend {
 
 		return nil, backend.ErrNotFound
 	})
+}
+
+func GetBackendsFromFlag() []backend.Backend {
+	o.Do(func() {
+		flag.StringVar(&envFiles, "config-env-files", ".env", "dot env file path separate by \",\" last file will override previous one\neg: application -config-env-files=\".env,.env.test\"\nwill load .env file then override with .env.test\n")
+		flag.Parse()
+	})
+	return GetBackends(strings.Split(envFiles, ",")...)
+}
+
+func GetBackends(paths ...string) []backend.Backend {
+	var backends []backend.Backend
+	for _, dotFile := range paths {
+		if _, err := os.Stat(dotFile); err == nil {
+			backends = append(backends, NewBackend(dotFile))
+		}
+	}
+	return backends
 }

--- a/dotenv/dotenv_test.go
+++ b/dotenv/dotenv_test.go
@@ -2,8 +2,10 @@ package dotenv_test
 
 import (
 	"context"
+	"os"
 	"testing"
 
+	"github.com/etf1/go-config"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/etf1/go-config/dotenv"
@@ -35,4 +37,77 @@ func TestNewBackend(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "my value", string(result))
 	})
+}
+
+func TestNewBackend_Multiple(t *testing.T) {
+	b := dotenv.NewBackend("testdata/.env", "testdata/.env.other")
+
+	t.Run("Key format unexpected", func(t *testing.T) {
+		result, err := b.Get(context.TODO(), "invalid key with space")
+		assert.EqualError(t, err, "dotenv variable format expected \\w+, \"invalid key with space\" given")
+		assert.Equal(t, "", string(result))
+	})
+
+	t.Run("Key Not Found", func(t *testing.T) {
+		result, err := b.Get(context.TODO(), "test")
+		assert.EqualError(t, err, "key not found")
+		assert.Equal(t, "", string(result))
+	})
+
+	t.Run("Key Matched", func(t *testing.T) {
+		result, err := b.Get(context.TODO(), "my_string")
+		assert.NoError(t, err)
+		assert.Equal(t, "my other value", string(result))
+	})
+}
+
+func TestGetBackend(t *testing.T) {
+	t.Run("One Backend", func(t *testing.T) {
+		backends := dotenv.GetBackends("testdata/.env")
+		assert.Len(t, backends, 1)
+	})
+
+	t.Run("Two Backend", func(t *testing.T) {
+		backends := dotenv.GetBackends("testdata/.env", "testdata/.env.other")
+		assert.Len(t, backends, 2)
+	})
+
+	t.Run("File Not found", func(t *testing.T) {
+		backends := dotenv.GetBackends("testdata/.env", "unexisting.file")
+		assert.Len(t, backends, 1)
+	})
+}
+
+// This function will replace os.Args in order to simulate only wanted flags
+func replaceOSArgs(flags ...string) func() {
+	originalArgs := os.Args
+	os.Args = append([]string{originalArgs[0]}, flags...)
+	return func() {
+		os.Args = originalArgs
+	}
+}
+
+func TestGetBackendsFromFlag(t *testing.T) {
+	defer replaceOSArgs("-config-env-files=testdata/.env,testdata/.env.other")()
+	backends := dotenv.GetBackendsFromFlag()
+	assert.Len(t, backends, 2)
+}
+
+type Conf struct {
+	Param1 string `config:"my_string"`
+	Param2 bool   `config:"my_bool"`
+	Param3 string `config:"param3"`
+}
+
+func TestNewBackend_MultipleFiles(t *testing.T) {
+	defer replaceOSArgs("-config-env-files=testdata/.env,testdata/.env.other")()
+	baseConfig := &Conf{
+		Param1: "param1 default value",
+		Param3: "param3 default value",
+	}
+	l := config.NewDefaultConfigLoader()
+	assert.Nil(t, l.Load(context.Background(), baseConfig))
+	assert.Equal(t, "my other value", baseConfig.Param1)
+	assert.True(t, baseConfig.Param2)
+	assert.Equal(t, "param3 default value", baseConfig.Param3)
 }

--- a/dotenv/testdata/.env.other
+++ b/dotenv/testdata/.env.other
@@ -1,0 +1,1 @@
+my_string=my other value

--- a/loader.go
+++ b/loader.go
@@ -3,7 +3,6 @@ package config
 import (
 	"context"
 	"log"
-	"os"
 
 	"github.com/heetch/confita"
 	"github.com/heetch/confita/backend"
@@ -12,8 +11,6 @@ import (
 	"github.com/etf1/go-config/dotenv"
 	"github.com/etf1/go-config/env"
 )
-
-var DefaultConfigLoader = NewDefaultConfigLoader()
 
 type Loader struct {
 	backends []backend.Backend
@@ -53,14 +50,6 @@ func NewConfigLoader(backends ...backend.Backend) *Loader {
 	return &Loader{backends: backends}
 }
 
-func Load(ctx context.Context, to interface{}) error {
-	return DefaultConfigLoader.Load(ctx, to)
-}
-
-func LoadOrFatal(ctx context.Context, to interface{}) {
-	DefaultConfigLoader.LoadOrFatal(ctx, to)
-}
-
 /*
  * Create Loader preconfigured with:
  * - .env file loader if file exist
@@ -68,15 +57,10 @@ func LoadOrFatal(ctx context.Context, to interface{}) {
  * - flags loader
  */
 func NewDefaultConfigLoader() *Loader {
-	builder := NewConfigLoader(
+	return NewConfigLoader(
+		dotenv.GetBackendsFromFlag()...
+	).AppendBackends(
 		env.NewBackend(),
 		flags.NewBackend(),
 	)
-
-	f := ".env"
-	if _, err := os.Stat(f); err == nil {
-		builder.PrependBackends(dotenv.NewBackend(f))
-	}
-
-	return builder
 }


### PR DESCRIPTION
# :warning: [BC BREAK] Remove DefaultConfigLoader

New Flag `-config-env-files` follow by dotenv files

```go
go run main.go -config-env-files=.env,.env.test
```
Will load `.env` first and overide with `.env.test` availables values

## Remove 

```go
var DefaultConfigLoader = NewDefaultConfigLoader()

func Load(ctx context.Context, to interface{}) error {
	return DefaultConfigLoader.Load(ctx, to)
}

func LoadOrFatal(ctx context.Context, to interface{}) {
	DefaultConfigLoader.LoadOrFatal(ctx, to)
}
```

## Migrate

```go
// FROM
config.LoadOrFatal(context.Background(), configStruct)
// TO
config.NewDefaultConfigLoader().LoadOrFatal(context.Background(), configStruct)

// FROM
config.Load(context.Background(), configStruct)
// TO
config.NewDefaultConfigLoader().Load(context.Background(), configStruct)
```